### PR TITLE
Fix for uneven hershey font tracking

### DIFF
--- a/xyscope.js
+++ b/xyscope.js
@@ -2142,7 +2142,7 @@ registerProcessor('xyscope-processor-${this.id}', class VectorProcessor extends 
 		s = s.replaceAll('\t', '    ')
 		let parts = s.split(/\r\n|\r|\n/)
 
-		let lineHeight = this.hfactor * this.hheight 
+		let lineHeight = this.hfactor * this.hheight * 2
 		let totalHeight = (lineHeight * parts.length) + (this.hleading * (parts.length - 1))
 		switch (this.textAlignY) {
  			case this.p.CENTER:
@@ -2223,7 +2223,7 @@ registerProcessor('xyscope-processor-${this.id}', class VectorProcessor extends 
 		if(!this.fontReady) return []
 		let parts = s.split(/\r\n|\r|\n/)
 
-		let lineHeight = this.hfactor * this.hheight
+		let lineHeight = this.hfactor * this.hheight * 2
 		let totalHeight = (lineHeight * parts.length) + (this.hleading * (parts.length - 1))
 
 		switch (this.textAlignY) {

--- a/xyscope.js
+++ b/xyscope.js
@@ -2142,7 +2142,7 @@ registerProcessor('xyscope-processor-${this.id}', class VectorProcessor extends 
 		s = s.replaceAll('\t', '    ')
 		let parts = s.split(/\r\n|\r|\n/)
 
-		let lineHeight = this.hfactor * this.hheight * 2
+		let lineHeight = this.hfactor * this.hheight
 		let totalHeight = (lineHeight * parts.length) + (this.hleading * (parts.length - 1))
 		switch (this.textAlignY) {
  			case this.p.CENTER:
@@ -2223,7 +2223,7 @@ registerProcessor('xyscope-processor-${this.id}', class VectorProcessor extends 
 		if(!this.fontReady) return []
 		let parts = s.split(/\r\n|\r|\n/)
 
-		let lineHeight = this.hfactor * this.hheight * 2
+		let lineHeight = this.hfactor * this.hheight
 		let totalHeight = (lineHeight * parts.length) + (this.hleading * (parts.length - 1))
 
 		switch (this.textAlignY) {

--- a/xyscope.js
+++ b/xyscope.js
@@ -2140,50 +2140,38 @@ registerProcessor('xyscope-processor-${this.id}', class VectorProcessor extends 
 		}
 
 		s = s.replaceAll('\t', '    ')
-		let parts = s.split(/\r?\n|\r|\n/g)
+		let parts = s.split(/\r\n|\r|\n/)
 
+		let lineHeight = this.hfactor * this.hheight 
+		let totalHeight = (lineHeight * parts.length) + (this.hleading * (parts.length - 1))
 		switch (this.textAlignY) {
-			case TOP:
-				y += this.hfactor * 12 + this.hleading
+ 			case this.p.CENTER:
+				y -= totalHeight / 2 - (lineHeight / 2)
 				break
-			case BOTTOM:
-				y -= (this.hfactor * 21 + this.hleading) * parts.length
+			case this.p.BOTTOM:
+				 y -= (totalHeight - lineHeight / 2)
+				break
+			case this.p.TOP:
+				y += (lineHeight / 2)
 				break
 			default:
-				if(parts.length > 1) {
-					y -= (this.hfactor * 21 + this.hleading) * parts.length / 2
-				}
 				break
 		}
 
 		let yOffset = y
 		for(let i = 0; i < parts.length; i++) {
 			this.textParse(parts[i], x, yOffset)
-			yOffset += this.hfactor * this.hheight + this.hleading
+			yOffset += lineHeight + this.hleading
 		}
 	}
 
 	textParse(s, x, y) {
-		x += 12 * this.hfactor
-
 		switch (this.textAlignX) {
-			case this.p.LEFT:
-				x -= 5 * this.hfactor
-				break
 			case this.p.CENTER:
-				x -= this.textWidth(s) / 2
+				x -= this.textWidthParse(s) / 2
 				break
 			case this.p.RIGHT:
-				x -= this.textWidth(s) - 5 * this.hfactor
-				break
-		}
-
-		switch (this.textAlignY) {
-			case this.p.TOP:
-				y += this.hfactor * 12
-				break
-			case this.p.BOTTOM:
-				y -= this.hfactor * 12
+				x -= this.textWidthParse(s)
 				break
 		}
 
@@ -2191,13 +2179,14 @@ registerProcessor('xyscope-processor-${this.id}', class VectorProcessor extends 
 		this.p.translate(x, y)
 
 		for(let i = 0; i < s.length; i++) {
-			this.drawCharacter(s.charAt(i))
+			let isLast = (i === s.length - 1)
+			this.drawCharacter(s.charAt(i), isLast)
 		}
 		this.p.pop()
 	}
 
 	textWidth(s) {
-		let parts = s.split(/\n|\r/)
+		let parts = s.split(/\r\n|\r|\n/)
 
 		let maxWidth = 0
 		for(let part of parts) {
@@ -2211,35 +2200,43 @@ registerProcessor('xyscope-processor-${this.id}', class VectorProcessor extends 
 
 	textWidthParse(s) {
 		let offx = 0
+		let tracking = 5
 		for(let k = 0; k < s.length; k++) {
 			let c = s.charAt(k)
 			let h = this.hersheyFont[c.charCodeAt(0) - 32]
-
+			
 			let startCol = h.indexOf(" ")
 
 			let hLeft = this.hershey2coord(h.charAt(startCol + 3))
 			let hRight = this.hershey2coord(h.charAt(startCol + 4))
-			let hWidth = (hRight - hLeft) * this.hfactor
-			offx += hWidth + 5 * this.hfactor
+			
+			offx += (hRight - hLeft) * this.hfactor
+		}
+		// calculate with tracking between characters
+		if (s.length > 1) {
+			offx += (s.length - 1) * tracking * this.hfactor
 		}
 		return offx
 	}
 
 	textPaths(s, x, y) {
 		if(!this.fontReady) return []
-		let parts = s.split(/\n|\r/)
+		let parts = s.split(/\r\n|\r|\n/)
+
+		let lineHeight = this.hfactor * this.hheight
+		let totalHeight = (lineHeight * parts.length) + (this.hleading * (parts.length - 1))
 
 		switch (this.textAlignY) {
-			case this.p.TOP:
-				y += this.hfactor * 12 + this.hleading
+ 			case this.p.CENTER:
+				y -= totalHeight / 2 - (lineHeight / 2)
 				break
 			case this.p.BOTTOM:
-				y -= (this.hfactor * 21 + this.hleading) * parts.length
+				 y -= (totalHeight - lineHeight / 2)
+				break
+			case this.p.TOP:
+				y += (lineHeight / 2)
 				break
 			default:
-				if(parts.length > 1) {
-					y -= (this.hfactor * 21 + this.hleading) * parts.length / 2
-				}
 				break
 		}
 
@@ -2247,23 +2244,20 @@ registerProcessor('xyscope-processor-${this.id}', class VectorProcessor extends 
 		let yOffset = y
 		for(let i = 0; i < parts.length; i++) {
 			this.textPathsParse(parts[i], x, yOffset, coords)
-			yOffset += this.hfactor * this.hheight + this.hleading
+			yOffset += lineHeight + this.hleading
 		}
 		return coords
 	}
 
 	textPathsParse(s, x, y, coords) {
-		x += 12 * this.hfactor
+		let tracking = 5
 
 		switch (this.textAlignX) {
-			case this.p.LEFT:
-				x -= 5 * this.hfactor
-				break
 			case this.p.CENTER:
-				x -= this.textWidth(s) / 2
+				x -= this.textWidthParse(s) / 2
 				break
 			case this.p.RIGHT:
-				x -= this.textWidth(s) - 5 * this.hfactor
+				x -= this.textWidthParse(s)
 				break
 		}
 
@@ -2277,9 +2271,10 @@ registerProcessor('xyscope-processor-${this.id}', class VectorProcessor extends 
 
 			let hLeft = this.hershey2coord(h.charAt(startCol + 3))
 			let hRight = this.hershey2coord(h.charAt(startCol + 4))
-			let hWidth = (hRight - hLeft) * this.hfactor
 
 			let hVertices = h.substring(startCol + 5).replace(/ R/g, " ").split(" ")
+
+			offx -= hLeft * this.hfactor
 
 			for(let vert of hVertices) {
 				let coord = []
@@ -2303,11 +2298,17 @@ registerProcessor('xyscope-processor-${this.id}', class VectorProcessor extends 
 				}
 				coords.push(coord)
 			}
-			offx += hWidth + 5 * this.hfactor
+
+			offx += hRight * this.hfactor
+			// add tracking
+			if (k < s.length - 1) { 
+				offx += tracking * this.hfactor
+			}
 		}
 	}
 
-	drawCharacter(c) {
+	drawCharacter(c, isLast) {
+		let tracking = 5
 		let h = this.hersheyFont[c.charCodeAt(0) - 32]
 
 		let startCol = h.indexOf(" ")
@@ -2330,7 +2331,10 @@ registerProcessor('xyscope-processor-${this.id}', class VectorProcessor extends 
 			}
 			this.endShape()
 		}
-		this.p.translate((hRight + 5) * this.hfactor, 0)
+    this.p.translate(hRight * this.hfactor, 0)
+    if (!isLast) {
+        this.p.translate(tracking * this.hfactor, 0)
+    }
 	}
 
 	hershey2coord(c) {

--- a/xyscope.js
+++ b/xyscope.js
@@ -2021,7 +2021,7 @@ registerProcessor('xyscope-processor-${this.id}', class VectorProcessor extends 
 12345  9HZLFL[ RLFYF RLPTP
 12345 23H]ZKYIWGUFQFOGMILKKNKSLVMXOZQ[U[WZYXZVZS RUSZS
 12345  9G]KFK[ RYFY[ RKPYP
-12345  3NVKFK[
+12345  3NVRFR[
 12345 11JZVFVVUYTZR[P[NZMYLVLT
 12345  9G\\KFK[ RYFKT RPOY[
 12345  6HYLFL[ RL[X[
@@ -2053,10 +2053,10 @@ registerProcessor('xyscope-processor-${this.id}', class VectorProcessor extends 
 12345  9MYWFUFSGRJR[ ROMVM
 12345 23I\\XMX]W\`VaTbQbOa RXPVNTMQMONMPLSLUMXOZQ[T[VZXX
 12345 11I\\MFM[ RMQPNRMUMWNXQX[
-12345  9NVKFMGNFMEKF RMMM[
+12345  9NVQFRGSFREQF RRMR[
 12345 12MWRFSGTFSERF RSMS^RaPbNb
 12345  9IZMFM[ RWMMW RQSX[
-12345  3NVKFK[
+12345  3NVRFR[
 12345 19CaGMG[ RGQJNLMOMQNRQR[ RRQUNWMZM\\N]Q][
 12345 11I\\MMM[ RMQPNRMUMWNXQX[
 12345 18I\\QMONMPLSLUMXOZQ[T[VZXXYUYSXPVNTMQM
@@ -2314,8 +2314,9 @@ registerProcessor('xyscope-processor-${this.id}', class VectorProcessor extends 
 
 		let hLeft = this.hershey2coord(h.charAt(startCol + 3))
 		let hRight = this.hershey2coord(h.charAt(startCol + 4))
-		let hWidth = (hRight - hLeft) * this.hfactor
 		let hVertices = h.substring(startCol + 5).replace(/ R/g, " ").split(" ")
+		
+		this.p.translate(-hLeft * this.hfactor, 0)
 
 		for(let vert of hVertices) {
 			this.beginShape()
@@ -2329,7 +2330,7 @@ registerProcessor('xyscope-processor-${this.id}', class VectorProcessor extends 
 			}
 			this.endShape()
 		}
-		this.p.translate(hWidth + 5 * this.hfactor, 0)
+		this.p.translate((hRight + 5) * this.hfactor, 0)
 	}
 
 	hershey2coord(c) {


### PR DESCRIPTION
Instead of drawing, then translating by both bearings, first translate the character by the left bearing, then draw, then translate by the right bearing to keep the spacing consistent. Also, restored some of the default font (hershey_futurl) vertice coordinates to match the [original data.](https://github.com/openimaj/openimaj/blob/master/core/core-image/src/main/resources/org/openimaj/image/typography/font/hershey/futural.jhf) 

More on the hershey font data format for future reference:
— [https://paulbourke.net/dataformats/hershey/](https://paulbourke.net/dataformats/hershey/)
— [https://coolbutuseless.github.io/package/hershey/articles/hershey-font-format.html](https://coolbutuseless.github.io/package/hershey/articles/hershey-font-format.html)